### PR TITLE
Content-Type should be handled by Restify

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ module.exports = function registerWebpackMiddlewareForRestify(restifyApp, config
         res.charSet('utf-8');
         res.writeHead(this.statusCode || 200, {
           'Content-Length': Buffer.byteLength(content),
-          'Content-Type': 'application/json',
         });
         res.write(content);
         res.end();


### PR DESCRIPTION
Setting the content-type to causes images to fail to render and it's not semantically correct. Restify should handle these based on the Accept-Headers sent by the client.
